### PR TITLE
fix leaking of time.Tick

### DIFF
--- a/tunnel/client.go
+++ b/tunnel/client.go
@@ -21,13 +21,14 @@ type ClientHub struct {
 }
 
 func (h *ClientHub) heartbeat() {
-	c := time.Tick(1 * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 
 	timeout := Timeout
 	if Timeout <= 0 {
 		timeout = TunnelMaxTimeout
 	}
-	for range c {
+	for range ticker.C {
 		// id overflow
 		span := h.sent - h.rcvd
 		if int(span) >= timeout {


### PR DESCRIPTION
As the [document](https://golang.org/pkg/time/#Tick) said, time.Tick will leak. And similar problem has been discussed [here](https://github.com/golang/go/issues/17757). 